### PR TITLE
Fix: Email confirmation redirect

### DIFF
--- a/src/hooks/useSignup.ts
+++ b/src/hooks/useSignup.ts
@@ -61,12 +61,17 @@ export const useSignup = () => {
         codeId = validationResult.code_id;
       }
 
-      // Step 2: Create user account
+      // Get current app origin for redirects
+      const origin = window.location.origin;
+      console.log('App origin for redirects:', origin);
+
+      // Step 2: Create user account with email confirmation redirect
       const { data: authData, error: signUpError } = await supabase.auth.signUp({
         email,
         password,
         options: {
           data: { username },
+          emailRedirectTo: `${origin}/dashboard`, // Redirect to dashboard after email confirmation
         },
       });
 

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -12,12 +12,22 @@ export const supabase = createClient(supabaseUrl, supabaseAnonKey, {
   auth: {
     autoRefreshToken: true,
     persistSession: true,
-    detectSessionInUrl: true, // Enable this to let Supabase detect auth tokens in the URL
+    detectSessionInUrl: true,
     flowType: 'pkce',
   },
 });
 
-// Debug listener for auth events - helpful for troubleshooting
+// Enhanced debug listener for auth events with more detailed information
 supabase.auth.onAuthStateChange((event, session) => {
-  console.log(`Auth state changed: ${event}`, session ? 'Session exists' : 'No session');
+  console.log(`Auth state changed: ${event}`, {
+    hasSession: !!session,
+    event,
+    // Log token type if session exists to help debug 
+    tokenType: session?.token_type,
+    // Add URL info to debug redirects
+    currentUrl: window.location.href,
+    pathname: window.location.pathname,
+    search: window.location.search,
+    hash: window.location.hash,
+  });
 });


### PR DESCRIPTION
The email confirmation link was incorrectly redirecting to the password reset page.  This commit addresses this issue, ensuring that the confirmation link redirects to the dashboard instead.