### PR TITLE
fix: Improve Stripe webhook error handling and fix DB constraint

### DIFF
--- a/supabase/functions/verify-stripe-subscription/index.ts
+++ b/supabase/functions/verify-stripe-subscription/index.ts
@@ -78,9 +78,20 @@ serve(async (req) => {
       headers: { ...corsHeaders, "Content-Type": "application/json" }
     });
   } catch (error) {
-    const errorMessage = error instanceof Error ? error.message : String(error);
-    logStep("Global error", { error: errorMessage });
-    return new Response(JSON.stringify({ error: errorMessage }), {
+    let detailedErrorMessage;
+    if (error instanceof Error) {
+      detailedErrorMessage = error.message;
+    } else if (typeof error === 'object' && error !== null) {
+      try {
+        detailedErrorMessage = JSON.stringify(error, Object.getOwnPropertyNames(error));
+      } catch (e) {
+        detailedErrorMessage = JSON.stringify(error);
+      }
+    } else {
+      detailedErrorMessage = String(error);
+    }
+    logStep("Global error", { error: detailedErrorMessage });
+    return new Response(JSON.stringify({ error: detailedErrorMessage }), {
       status: 500,
       headers: { ...corsHeaders, "Content-Type": "application/json" }
     });
@@ -118,9 +129,20 @@ async function handleWebhookEvent(event: any) {
       });
     }
   } catch (error) {
-    const errorMessage = error instanceof Error ? error.message : String(error);
-    logStep("Error processing webhook", { error: errorMessage, eventType: event.type });
-    return new Response(JSON.stringify({ error: errorMessage }), {
+    let detailedErrorMessage;
+    if (error instanceof Error) {
+      detailedErrorMessage = error.message;
+    } else if (typeof error === 'object' && error !== null) {
+      try {
+        detailedErrorMessage = JSON.stringify(error, Object.getOwnPropertyNames(error));
+      } catch (e) {
+        detailedErrorMessage = JSON.stringify(error);
+      }
+    } else {
+      detailedErrorMessage = String(error);
+    }
+    logStep("Error processing webhook", { error: detailedErrorMessage, eventType: event.type });
+    return new Response(JSON.stringify({ error: detailedErrorMessage }), {
       status: 500,
       headers: { ...corsHeaders, "Content-Type": "application/json" }
     });
@@ -380,8 +402,20 @@ async function handleCheckoutSessionCompleted(session: any) {
       email: customerEmail
     });
   } catch (error) {
+    let detailedErrorMessage;
+    if (error instanceof Error) {
+      detailedErrorMessage = error.message;
+    } else if (typeof error === 'object' && error !== null) {
+      try {
+        detailedErrorMessage = JSON.stringify(error, Object.getOwnPropertyNames(error));
+      } catch (e) {
+        detailedErrorMessage = JSON.stringify(error);
+      }
+    } else {
+      detailedErrorMessage = String(error);
+    }
     logStep("Error processing payment", { 
-      error: error instanceof Error ? error.message : String(error),
+      error: detailedErrorMessage,
       sessionId: session.id
     });
     throw error;

--- a/supabase/migrations/20250526131735_add_unique_constraint_to_subscriptions_email.sql
+++ b/supabase/migrations/20250526131735_add_unique_constraint_to_subscriptions_email.sql
@@ -1,0 +1,22 @@
+-- Add a UNIQUE constraint to the email column in the subscriptions table.
+-- This is to support the ON CONFLICT(email) clause used in the verify-stripe-subscription Edge Function,
+-- which is the source of the "42P10" error ("no unique or exclusion constraint matching the ON CONFLICT specification").
+--
+-- IMPORTANT: Before applying this migration, ensure that there are no existing duplicate email values
+-- in the 'public.subscriptions' table. If duplicates exist, this migration will fail.
+-- Duplicate emails must be resolved manually (e.g., by updating or deleting records) before this constraint can be added.
+
+ALTER TABLE public.subscriptions
+ADD CONSTRAINT subscriptions_email_unique UNIQUE (email);
+
+-- Note on user_id constraint:
+-- The Supabase function at 'supabase/functions/stripe-webhook/index.ts' (which might be an older or alternative webhook)
+-- uses 'ON CONFLICT (user_id)'. If 'user_id' is also intended to be a unique identifier for a user's subscription,
+-- a unique constraint should exist on 'user_id' as well.
+-- If such a constraint is needed and does not exist, it can be added with a command like:
+--
+-- ALTER TABLE public.subscriptions
+-- ADD CONSTRAINT subscriptions_user_id_unique UNIQUE (user_id);
+--
+-- Again, ensure no duplicate 'user_id' values exist before applying such a constraint.
+-- For this migration, we are only adding the 'email' constraint as it directly addresses the error in 'verify-stripe-subscription'.


### PR DESCRIPTION
- Modified `supabase/functions/verify-stripe-subscription/index.ts` to provide detailed error messages in logs, preventing "[object Object]" errors.
- Created SQL migration `supabase/migrations/20250526131735_add_unique_constraint_to_subscriptions_email.sql` to add a UNIQUE constraint on the `email` column in the `subscriptions` table. This resolves the "42P10" error (no unique or exclusion constraint matching the ON CONFLICT specification) when `ON CONFLICT(email)` is used in the Edge Function.

The migration includes notes on handling pre-existing duplicate emails and a consideration for a unique constraint on `user_id` if needed by other parts of your system.